### PR TITLE
Support Ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Allow activesupport >=6 as a dependency for ruby-3.0.2.
+  [cyberark/conjur-cli#339](https://github.com/cyberark/conjur-cli/pull/339)
+- Add Ruby 3 tests in CI.
+- Set Ruby 3 as default.
+  [cyberark/conjur-cli#344](https://github.com/cyberark/conjur-cli/pull/344)
+- Bump `conjur-api-ruby` gem.
+- Bump `rake` gem.
 
 ## [6.2.5] - 2021-09-29
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # docker 17.06+ will let us do this:
-# ARG RUBY_VERSION=2.7
+# ARG RUBY_VERSION=3.0
 FROM ruby:${RUBY_VERSION}
 
 RUN mkdir /src

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-#ruby=ruby-2.7.0
+#ruby=ruby-3.0
 #ruby-gemset=conjur-cli
 
 # Specify your gem's dependencies in conjur.gemspec

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
       }
     }
 
-    stage('Test 2.5') {
+    stage('Test Ruby 2.5') {
       environment {
         RUBY_VERSION = '2.5'
       }
@@ -42,7 +42,7 @@ pipeline {
       }
     }
 
-    stage('Test 2.6') {
+    stage('Test Ruby 2.6') {
       environment {
         RUBY_VERSION = '2.6'
       }
@@ -58,9 +58,25 @@ pipeline {
       }
     }
 
-    stage('Test 2.7') {
+    stage('Test Ruby 2.7') {
       environment {
         RUBY_VERSION = '2.7'
+      }
+
+      steps {
+        sh './test.sh'
+      }
+
+      post {
+        always {
+          junit 'spec/reports/*.xml, features/reports/*.xml'
+        }
+      }
+    }
+
+    stage('Test Ruby 3.0') {
+      environment {
+        RUBY_VERSION = '3.0'
       }
 
       steps {

--- a/conjur-cli.gemspec
+++ b/conjur-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   # Filter out development only executables
   gem.executables -= %w{parse-changelog.sh}
 
-  gem.add_dependency 'activesupport', '>= 4.2'
+  gem.add_dependency 'activesupport', '~> 6.0'
   gem.add_dependency 'conjur-api', '~> 5.3'
   gem.add_dependency 'deep_merge', '~> 1.0'
   gem.add_dependency 'gli', '>=2.8.0'
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'io-grab', '~> 0.0'
   gem.add_development_dependency 'json_spec'
   gem.add_development_dependency 'pry-byebug'
-  gem.add_development_dependency 'rake', '~> 12.3.3'
+  gem.add_development_dependency 'rake', '~> 13.0'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # Constants
-RUBY_VERSION_DEFAULT="2.7"
+RUBY_VERSION_DEFAULT="3.0"
 
 # Arguments
 RUBY_VERSION=${1-${RUBY_VERSION_DEFAULT}}

--- a/test.sh
+++ b/test.sh
@@ -1,11 +1,15 @@
 #!/bin/bash -ex
 
-: ${RUBY_VERSION=2.7}
+: ${RUBY_VERSION=3.0}
 
 # My local RUBY_VERSION is set to ruby-#.#.# so this allows running locally.
 RUBY_VERSION=$(cut -d '-' -f 2 <<< $RUBY_VERSION)
 
 main() {
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker does not seem to be running, run it first and retry"
+    exit 1
+  fi
 
   # set up the containers to run in their own namespace
   COMPOSE_PROJECT_NAME="$(basename "$PWD")_$(openssl rand -hex 3)"


### PR DESCRIPTION
### Desired Outcome

Conjur cli support ruby 3.

### Implemented Changes

Changed `activesupport` dependency condition - an enabler for other repos for ruby-3.0.2.
Bump `conjur-api-ruby` gem to v5.3.7.
Bump `rake` gem.
Added Ruby 3 tests in Jenkinsfile.
Set ruby 3 as default in all related scripts

### Connected Issue/Story

CyberArk internal issue link: [ONYX-10396](https://ca-il-jira.il.cyber-ark.com:8443/secure/RapidBoard.jspa?rapidView=1424&view=detail&selectedIssue=ONYX-10396)

### Definition of Done

All tests are green.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
