### PR TITLE
Upgrade Dockerfile base images to ubuntu:21.10

### DIFF
--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:21.10
 
 RUN apt-get update -y && apt-get install -y software-properties-common git build-essential
 

--- a/Dockerfile.publish
+++ b/Dockerfile.publish
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:21.10
 
 RUN apt-get update -y && apt-get install -y curl
 

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -5,7 +5,7 @@
 # then installs the CLI system-wide.
 #
 # Entrypoint is bash, with `conjur` command available.
-FROM ubuntu:20.04
+FROM ubuntu:21.10
 
 ENV CONJUR_MAJOR_VERSION=5 \
     CONJUR_VERSION=5 \

--- a/Dockerfile.validate-packaging
+++ b/Dockerfile.validate-packaging
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:21.10
 
 RUN apt-get update && apt-get install -y software-properties-common
 RUN apt-add-repository ppa:brightbox/ruby-ng


### PR DESCRIPTION
### Desired Outcome

Upgrade Dockerfile base images to ubuntu:21.10 to fix snyk vulnerabilities.

### Implemented Changes

Updated base images in the following files:
- Dockerfile.fpm
- Dockerfile.publish
- Dockerfile.standalone
- Dockerfile.validate-packaging

Dockerfile uses the ruby image instead of ubuntu so there was no need to upgrade it.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-15962](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15962)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
