### PR TITLE
Fix Jenkins build: error when retrieving API key

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -42,7 +42,7 @@ start_conjur() {
 }
 
 run_tests() {
-  env CONJUR_AUTHN_API_KEY=$(docker-compose exec -T conjur rails r "print Credentials['cucumber:user:admin'].api_key") \
+  env CONJUR_AUTHN_API_KEY=$(docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin) \
     docker-compose run test "$@"
 }
 


### PR DESCRIPTION
### Desired Outcome

Jenkins was failing with the following logs:
```
env 'CONJUR_AUTHN_API_KEY=[deprecated]' Dry::Struct::Value is deprecated and will be removed in the next major version /opt/conjur-server/app/domain/util/submodules.rb:7:in '`const_get'\''' 1k7yph21x8ff1xepn59w35a78z9c535eb1ztjnay18exjv93jnjc1j docker-compose run test
env: ‘Dry::Struct::Value’: No such file or directory
```

The `Dry::Struct::Value` deprecation message is output to stdout whenever `rails` is called in the Conjur container, like in this command:
```
docker-compose exec -T conjur rails r "print Credentials['cucumber:user:admin'].api_key"
```

### Implemented Changes

- Replace the `rails` commands with a `conjurctl` command to retrieve the admin user's API key.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-20425](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-20425)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
