### PR TITLE
Update Jenkinsfile to fix push to RubyGems

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,12 +110,12 @@ pipeline {
 
       steps {
         // Clean up first
-        sh 'docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd'
+        sh 'git clean -fxd'
 
         sh './publish.sh'
 
         // Clean up again...
-        sh 'docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd'
+        sh 'git clean -fxd'
         deleteDir()
       }
     }


### PR DESCRIPTION
### Desired Outcome

Jenkins build fails when publishing the CLI to RubyGems.org.

```
Currently fails with:

[2022-05-31T18:38:28.294Z] fatal: unsafe repository ('/src' is owned by someone else)
[2022-05-31T18:38:28.294Z] To add an exception for this directory, call:
[2022-05-31T18:38:28.294Z]
[2022-05-31T18:38:28.294Z] git config --global --add safe.directory /src

when running:

sh 'docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd' in the Jenkinsfile.
```

### Implemented Changes

Instead of running `git` commands from an `alpine/git` container, I've moved the commands to run directly in the shell.

If we still want to use an `alpine/git` container, we can run something like this, but it probably isn't necessary:
```
sh '''
  docker run -i --rm \
    --entrypoint /bin/sh \
    -v $PWD:/src -w /src \
    alpine/git -c '
      git config --global --add safe.directory /src
      git clean -fxd
    '
'''
```

### Connected Issue/Story

CyberArk internal issue link: [ONYX-21426](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-21426)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
