### PR TITLE
Add trivy.yaml to skip cc-test-reporter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,13 @@
-* @cyberark/community-and-integrations-team @conjurinc/community-and-integrations-team @conjurdemos/community-and-integrations-team
+* @cyberark/community-and-integrations-team
 
 # Changes to .trivyignore require Security Architect approval
-.trivyignore @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
+.trivyignore @cyberark/security-architects
 
 # Changes to .codeclimate.yml require Quality Architect approval
-.codeclimate.yml @cyberark/quality-architects @conjurinc/quality-architects @conjurdemos/quality-architects
+.codeclimate.yml @cyberark/quality-architects
 
 # Changes to SECURITY.md require Security Architect approval
-SECURITY.md @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
+SECURITY.md @cyberark/security-architects
 
 # Changes to trivy.yaml require Security Architect approval
 trivy.yaml @cyberark/security-architects

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,6 @@
 
 # Changes to SECURITY.md require Security Architect approval
 SECURITY.md @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
+
+# Changes to trivy.yaml require Security Architect approval
+trivy.yaml @cyberark/security-architects

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,4 @@
+scan:
+  skip-files:
+    # Skip the cc-test-reporter since we can't update the code. We'll monitor it elsewhere.
+    - usr/src/cli-ruby/cc-test-reporter


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Stop CLI build from failing when trivy scans cc-test-reporter

### Implemented Changes

Add a trivy.yaml file. This PR won't pass until https://github.com/conjurinc/jenkins-pipeline-library/pull/95 is merged.